### PR TITLE
Feature/fp16 precision fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # JetBrains PyCharm IDE
 .idea/
 
+# VsCode IDE
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/fairseq/criterions/adaptive_loss.py
+++ b/fairseq/criterions/adaptive_loss.py
@@ -119,7 +119,7 @@ class AdaptiveLoss(FairseqCriterion):
 
         # because we're using a mean reduction, we don't need to divide by sample_size
         metrics.log_scalar(
-            "loss", loss_sum / math.log(2), sample_size, round=3
+            "loss", loss_sum / 3 / math.log(2), sample_size, round=3
         )
         # metrics.log_scalar(
         #     "loss", loss_sum / sample_size / math.log(2), sample_size, round=3

--- a/fairseq/criterions/adaptive_loss.py
+++ b/fairseq/criterions/adaptive_loss.py
@@ -13,13 +13,13 @@ from fairseq.criterions import FairseqCriterion, register_criterion
 from fairseq.dataclass import FairseqDataclass
 from fairseq.dataclass.constants import DDP_BACKEND_CHOICES
 from omegaconf import II
-
+from typing import List
 
 @dataclass
 class AdaptiveLossConfig(FairseqDataclass):
     sentence_avg: bool = II("optimization.sentence_avg")
     ddp_backend: DDP_BACKEND_CHOICES = II("distributed_training.ddp_backend")
-
+    update_freq: List[int] = II("optimization.update_freq")
 
 @register_criterion("adaptive_loss", dataclass=AdaptiveLossConfig)
 class AdaptiveLoss(FairseqCriterion):
@@ -27,9 +27,10 @@ class AdaptiveLoss(FairseqCriterion):
     graphical processing units (GPU), described in the paper "Efficient softmax approximation for GPUs"
     (http://arxiv.org/abs/1609.04309)."""
 
-    def __init__(self, task, sentence_avg):
+    def __init__(self, task, sentence_avg, use_mean_reduction):
         super().__init__(task)
         self.sentence_avg = sentence_avg
+        self.use_mean_reduction = use_mean_reduction
 
     @classmethod
     def build_criterion(cls, cfg: AdaptiveLossConfig, task):
@@ -39,9 +40,82 @@ class AdaptiveLoss(FairseqCriterion):
                 "version of DistributedDataParallel. Please use "
                 "`--ddp-backend=legacy_ddp` instead."
             )
-        return cls(task, cfg.sentence_avg)
+    
+        # Using a mean reduction with AdaptiveLoss may improve precision with fp16,
+        # but doesn't give correct outputs when accumulating loss/gradients over more than
+        # a single batch.
+        # The mean reduction will be applied automatically if gradient accumulation is
+        # disabled (update_freq == 1).
+        assert len(cfg.update_freq) == 1
+        return cls(task, cfg.sentence_avg, cfg.update_freq[0] == 1)
+    
+    def forward(self, model, sample, train_sample, reduce=True):
+        """
+        Compute the loss for the given sample. If the sample comes from the training set and
+        self.use_mean_reduction is True, then the loss will be computed using a mean reduction.
+        Otherwise, the loss will be computed using a sum reduction. 
 
-    def forward(self, model, sample, reduce=True):
+        Returns a tuple with three elements:
+        1) the loss
+        2) the sample size, which is used as the denominator for the gradient
+        3) logging outputs to display while training
+        """
+        if train_sample and self.use_mean_reduction:
+            return self._forward_with_mean(model, sample, reduce)
+        else:
+            return self._forward_with_sum(model, sample, reduce)
+        
+    def _forward_with_sum(self, model, sample, reduce=True):
+        """Compute the loss for the given sample.
+
+        Returns a tuple with three elements:
+        1) the loss
+        2) the sample size, which is used as the denominator for the gradient
+        3) logging outputs to display while training
+        """
+
+        assert (
+            hasattr(model.decoder, "adaptive_softmax")
+            and model.decoder.adaptive_softmax is not None
+        )
+        adaptive_softmax = model.decoder.adaptive_softmax
+
+        net_output = model(**sample["net_input"])
+        orig_target = model.get_targets(sample, net_output)
+
+        nsentences = orig_target.size(0)
+        orig_target = orig_target.view(-1)
+
+        bsz = orig_target.size(0)
+
+        logits, target = adaptive_softmax(net_output[0], orig_target)
+        assert len(target) == len(logits)
+
+        loss = net_output[0].new(1 if reduce else bsz).zero_()
+
+        for i in range(len(target)):
+            if target[i] is not None:
+                assert target[i].min() >= 0 and target[i].max() <= logits[i].size(1)
+                loss += F.cross_entropy(
+                    logits[i],
+                    target[i],
+                    ignore_index=self.padding_idx,
+                    reduction="sum" if reduce else "none"
+                )
+
+        orig = utils.strip_pad(orig_target, self.padding_idx)
+        ntokens = orig.numel()
+        sample_size = sample["target"].size(0) if self.sentence_avg else ntokens
+        logging_output = {
+            "loss": loss.data,
+            "ntokens": ntokens,
+            "nsentences": nsentences,
+            "sample_size": sample_size,
+        }
+
+        return loss, sample_size, logging_output
+
+    def _forward_with_mean(self, model, sample, reduce=True):
         """Compute the loss for the given sample.
 
         Returns a tuple with three elements:
@@ -97,8 +171,12 @@ class AdaptiveLoss(FairseqCriterion):
                 loss += (loss_i / divisor)
 
         orig = utils.strip_pad(orig_target, self.padding_idx)
-        ntokens = orig.numel()
-        sample_size = sample["target"].size(0) if self.sentence_avg else ntokens
+
+        # set sample_size = 1 since we're using a mean reduction. 
+        # set ntokens = 1 since we're using a mean reduction; we don't want to output nll_loss
+        assert self.sentence_avg == False
+        ntokens = 1
+        sample_size = 1
         logging_output = {
             "loss": loss.data,
             "ntokens": ntokens,
@@ -117,13 +195,9 @@ class AdaptiveLoss(FairseqCriterion):
             sum(log.get("sample_size", 0) for log in logging_outputs)
         )
 
-        # because we're using a mean reduction, we don't need to divide by sample_size
         metrics.log_scalar(
-            "loss", loss_sum / 3 / math.log(2), sample_size, round=3
+            "loss", loss_sum / sample_size / math.log(2), sample_size, round=3
         )
-        # metrics.log_scalar(
-        #     "loss", loss_sum / sample_size / math.log(2), sample_size, round=3
-        # )
 
         if sample_size != ntokens:
             metrics.log_scalar(
@@ -143,5 +217,20 @@ class AdaptiveLoss(FairseqCriterion):
         Whether the logging outputs returned by `forward` can be summed
         across workers prior to calling `reduce_metrics`. Setting this
         to True will improves distributed training speed.
+        """
+        return True
+    
+    def different_forward_for_train_test(self) -> bool:
+        """
+        Whether the `forward` method should be invoked differently for
+        training vs. validation data. If True, a criterion's forward()
+        method should accept a third positional warg train_sample which indicates
+        if the passed sample came from the training set. This is False
+        for all criterion except AdaptiveLoss. 
+
+        For AdaptiveLoss, we will use a different forward() method if
+        we're using a mean reduction over training passes. Validation
+        passes should still use the sum reduction since the loss needs
+        to be accumulated over multiple batches. 
         """
         return True

--- a/fairseq/criterions/fairseq_criterion.py
+++ b/fairseq/criterions/fairseq_criterion.py
@@ -101,6 +101,16 @@ class FairseqCriterion(_Loss):
         across workers prior to calling `reduce_metrics`. Setting this
         to True will improves distributed training speed.
         """
+        return False    
+
+    def different_forward_for_train_test(self) -> bool:
+        """
+        Whether the `forward` method should be invoked differently for
+        training vs. validation data. If True, a criterion's forward()
+        method should accept a third positional warg train_sample which indicates
+        if the passed sample came from the training set. This is False
+        for all criterion except AdaptiveLoss. 
+        """
         return False
 
 

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -529,7 +529,10 @@ class FairseqTask(object):
         model.set_num_updates(update_num)
         with torch.autograd.profiler.record_function("forward"):
             with torch.cuda.amp.autocast(enabled=(isinstance(optimizer, AMPOptimizer))):
-                loss, sample_size, logging_output = criterion(model, sample)
+                if criterion.different_forward_for_train_test():
+                    loss, sample_size, logging_output = criterion(model, sample, True)
+                else:
+                    loss, sample_size, logging_output = criterion(model, sample)
         if ignore_grad:
             loss *= 0
         with torch.autograd.profiler.record_function("backward"):
@@ -539,7 +542,10 @@ class FairseqTask(object):
     def valid_step(self, sample, model, criterion):
         model.eval()
         with torch.no_grad():
-            loss, sample_size, logging_output = criterion(model, sample)
+            if criterion.different_forward_for_train_test():
+                loss, sample_size, logging_output = criterion(model, sample, False)
+            else:
+                loss, sample_size, logging_output = criterion(model, sample)
         return loss, sample_size, logging_output
 
     def optimizer_step(self, optimizer, model, update_num):

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -943,8 +943,7 @@ class Trainer(object):
                     if not self.cfg.optimization.use_bmuf or self._sync_stats()
                     else 1
                 )
-                # since the adaptive_loss is using an effective mean reduction, just multiply by numer
-                # self.optimizer.multiply_grads(numer)
+                self.optimizer.multiply_grads(numer / (sample_size or 1.0))
                 
                 # self.optimizer.multiply_grads(numer / (sample_size or 1.0))
                 # Note: (sample_size or 1.0) handles the case of a zero gradient, in a

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -944,8 +944,6 @@ class Trainer(object):
                     else 1
                 )
                 self.optimizer.multiply_grads(numer / (sample_size or 1.0))
-                
-                # self.optimizer.multiply_grads(numer / (sample_size or 1.0))
                 # Note: (sample_size or 1.0) handles the case of a zero gradient, in a
                 # way that avoids CPU/device transfers in case sample_size is a GPU or
                 # TPU object. The assumption is that the gradient itself is also 0.

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -944,7 +944,7 @@ class Trainer(object):
                     else 1
                 )
                 # since the adaptive_loss is using an effective mean reduction, just multiply by numer
-                self.optimizer.multiply_grads(numer)
+                # self.optimizer.multiply_grads(numer)
                 
                 # self.optimizer.multiply_grads(numer / (sample_size or 1.0))
                 # Note: (sample_size or 1.0) handles the case of a zero gradient, in a


### PR DESCRIPTION
This PR fixes precision issues when training with the `--fp16` option. The fairseq codebase attempts to be general by using a sum reduction in call to `F.cross_entropy()` inside the `AdaptiveLoss` class. For example, this formulation allows for gradient accumulation (via `--update-freq`) to be applied over multiple batches to simulate a larger batch. However, we have GPUs large enough to push a lot of tokens per batch, so we won't use this option. Unfortunately, when the batch size is large enough, the loss at the beginning of training can be too large to fit in a `torch.float16`, making it impossible to converge. 

This PR pushes changes that quickly and dirtily circumvent this problem. Inside the `FairseqCriterion` class, a new `@staticmethod different_forward_for_train_test()` returns `True` for `AdaptiveLoss` only, allowing a `mean` reduction to be used when `forward()` is called during a training step. This returns the correct loss over a single batch and returns a `sample_size` of 1 to ensure that the gradient is not additionally scaled by the original `sample_size`, as the mean reduction automatically scales the loss by `sample_size`. During a validation/test step, the loss calculation uses the original `forward()`, which uses a sum reduction over the batches in the validation/test set. 

In reality, to make this a feature, I believe this option might still be applicable over multiple batches. For example, during a validation step with `AdaptiveLoss`, I think the true loss could be recovered from the individual mean-losses using the loss value and the sample_size reported in a call to `AdaptiveLoss.reduce_metrics()` For example, over two batches with mean-reduced losses $L_1=\frac{\ell_1}{b_1}, L_2\frac{\ell_2}{b_2}$, we could get the full mean loss with $\frac{b_1 L_1 + b_2 L_2}{b_1+b_2}$. With a careful use of scaling factors and loss storage, we might be able to compute this accurately in fp16 without incurring an `inf` from computing $b_1L_1 + b_2L_2$. 

Furthermore, this might be applicable to multiple loss functions. If this is the case, a new option `--use-mean-reduction` could be created, with behavior that alters a criterion that automatically assumes to use a sum reduction to have the behavior described above. If this isn't clear, the `AdaptiveLoss` class has a line that says `F.cross_entropy(..., reduction = 'sum' if reduce else 'none')`. 