### PR TITLE
Feature: Euclidean Attention

### DIFF
--- a/fairseq/models/transformer/transformer_config.py
+++ b/fairseq/models/transformer/transformer_config.py
@@ -251,6 +251,29 @@ class TransformerConfig(FairseqDataclass):
         }
     )
 
+    # Euclidean Attention arguments
+    use_euclidean_attention: bool = field(
+        default=False,
+        metadata={
+            "help": "if True, uses Euclidean distance instead of dot-product inside softmax"
+        }
+    )
+
+    # Temperature scaling arguments
+    learned_temperature: bool = field(
+        default=False,
+        metadata={
+            "help": "if True, temperature parameter(s) are learned to augment softmax instead\
+                     of the default temperature of 1."
+        }
+    )
+    per_token_temperature: bool = field(
+        default=False,
+        metadata={
+            "help": "if True, a temperature parameter is learned for each position of the context"
+        }
+    )
+
     # copied from transformer_lm but expected in transformer_decoder:
     no_decoder_final_norm: bool = field(
         default=False,

--- a/fairseq/models/transformer_lm.py
+++ b/fairseq/models/transformer_lm.py
@@ -226,6 +226,29 @@ class TransformerLanguageModelConfig(FairseqDataclass):
             "help": "if True, disables positional embeddings and uses ALiBi-modified attention"
         },
     )
+
+    # Euclidean Attention arguments
+    use_euclidean_attention: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "if True, uses Euclidean distance instead of dot-product inside softmax"
+        }
+    )
+
+    # Temperature scaling arguments
+    learned_temperature: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "if True, temperature parameter(s) are learned to augment softmax instead\
+                     of the default temperature of 1."
+        }
+    )
+    per_token_temperature: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "if True, a temperature parameter is learned for each position of the context"
+        }
+    )
     
     # options from other parts of the config
     max_tokens: int = II("task.max_tokens")
@@ -377,6 +400,14 @@ def base_lm_architecture(args):
         args, "share_decoder_input_output_embed", False
     )
     args.character_embeddings = safe_getattr(args, "character_embeddings", False)
+
+    args.use_euclidean_attention = safe_getattr(args, "use_euclidean_attention", False)
+
+    # If per_token_temperature is passed, assert that learned_temperature was, too
+    args.learned_temperature = safe_getattr(args, "learned_temperature", False)
+    args.per_token_temperature = safe_getattr(args, "per_token_temperature", False)
+    if args.per_token_temperature:
+        assert args.learned_temperature, "To learn a per-token temperature, please pass --learned-temperature to the training command"
 
     args.decoder_output_dim = safe_getattr(
         args, "decoder_output_dim", args.decoder_embed_dim

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn import Parameter
+import warnings
 
 try:
     from xformers.components.attention import build_attention
@@ -89,7 +90,10 @@ class MultiheadAttention(FairseqIncrementalDecoder):
         ] = None,  # This should be part of the config
         xformers_blocksparse_blocksize: Optional[
             int
-        ] = 16,  # This should be part of the config
+        ] = 16,  # This should be part of the config,
+        use_euclidean=False,
+        learned_temperature=False,
+        per_token_temperature=False,
     ):
         super().__init__(dictionary)
 
@@ -140,9 +144,19 @@ class MultiheadAttention(FairseqIncrementalDecoder):
         else:
             self.bias_k = self.bias_v = None
 
+        # Euclidean Attention config setup
+        self.use_euclidean = use_euclidean
+        self.learned_temperature = learned_temperature
+        self.temperature = Parameter(torch.Tensor(1), requires_grad=False)
+        if self.learned_temperature:
+            if per_token_temperature:
+                self.temperature = Parameter(torch.Tensor(embed_dim), requires_grad=True)
+            else:
+                self.temperature = Parameter(torch.Tensor(1), requires_grad=True)
+
         self.add_zero_attn = add_zero_attn
         self.beam_size = 1
-        self.reset_parameters()
+        self.reset_parameters() # TODO: do I need to add any logic to this function? 
 
         if self.use_xformers:
             xformers_att_config["dropout"] = xformers_att_config.get("dropout", dropout)
@@ -184,6 +198,12 @@ class MultiheadAttention(FairseqIncrementalDecoder):
             nn.init.xavier_normal_(self.bias_k)
         if self.bias_v is not None:
             nn.init.xavier_normal_(self.bias_v)
+
+        # Init the temperature param
+        if self.learned_temperature:
+            nn.init.uniform_(self.temperature) # draw from [0, 1]
+        else:
+            nn.init.constant_(self.temperature, 1.0) # use temperature=1 (same as normal softmax)
 
     def _get_reserve_head_index(self, num_heads_to_keep: int):
         k_proj_heads_norm = []
@@ -536,7 +556,7 @@ class MultiheadAttention(FairseqIncrementalDecoder):
                 )
 
             else:
-                return F.multi_head_attention_forward(
+                return self.multi_head_attention_forward(
                     query,
                     key,
                     value,
@@ -908,3 +928,307 @@ class MultiheadAttention(FairseqIncrementalDecoder):
 
         for key, value in items_to_add.items():
             state_dict[key] = value
+
+    def multi_head_attention_forward(self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        embed_dim_to_check: int,
+        num_heads: int,
+        in_proj_weight: Optional[Tensor],
+        in_proj_bias: Optional[Tensor],
+        bias_k: Optional[Tensor],
+        bias_v: Optional[Tensor],
+        add_zero_attn: bool,
+        dropout_p: float,
+        out_proj_weight: Tensor,
+        out_proj_bias: Optional[Tensor],
+        training: bool = True,
+        key_padding_mask: Optional[Tensor] = None,
+        need_weights: bool = True,
+        attn_mask: Optional[Tensor] = None,
+        use_separate_proj_weight: bool = False,
+        q_proj_weight: Optional[Tensor] = None,
+        k_proj_weight: Optional[Tensor] = None,
+        v_proj_weight: Optional[Tensor] = None,
+        static_k: Optional[Tensor] = None,
+        static_v: Optional[Tensor] = None,
+        average_attn_weights: bool = True,
+        ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""
+        Args:
+            query, key, value: map a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+            embed_dim_to_check: total dimension of the model.
+            num_heads: parallel attention heads.
+            in_proj_weight, in_proj_bias: input projection weight and bias.
+            bias_k, bias_v: bias of the key and value sequences to be added at dim=0.
+            add_zero_attn: add a new batch of zeros to the key and
+                        value sequences at dim=1.
+            dropout_p: probability of an element to be zeroed.
+            out_proj_weight, out_proj_bias: the output projection weight and bias.
+            training: apply dropout if is ``True``.
+            key_padding_mask: if provided, specified padding elements in the key will
+                be ignored by the attention. This is an binary mask. When the value is True,
+                the corresponding value on the attention layer will be filled with -inf.
+            need_weights: output attn_output_weights.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+            use_separate_proj_weight: the function accept the proj. weights for query, key,
+                and value in different forms. If false, in_proj_weight will be used, which is
+                a combination of q_proj_weight, k_proj_weight, v_proj_weight.
+            q_proj_weight, k_proj_weight, v_proj_weight, in_proj_bias: input projection weight and bias.
+            static_k, static_v: static key and value used for attention operators.
+            average_attn_weights: If true, indicates that the returned ``attn_weights`` should be averaged across heads.
+                Otherwise, ``attn_weights`` are provided separately per head. Note that this flag only has an effect
+                when ``need_weights=True.``. Default: True
+
+
+        Shape:
+            Inputs:
+            - query: :math:`(L, E)` or :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+            the embedding dimension.
+            - key: :math:`(S, E)` or :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - value: :math:`(S, E)` or :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+            the embedding dimension.
+            - key_padding_mask: :math:`(S)` or :math:`(N, S)` where N is the batch size, S is the source sequence length.
+            If a FloatTensor is provided, it will be directly added to the value.
+            If a BoolTensor is provided, the positions with the
+            value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+            - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
+            3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
+            S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
+            positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+            while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+            are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+            is provided, it will be added to the attention weight.
+            - static_k: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+            N is the batch size, E is the embedding dimension. E/num_heads is the head dimension.
+            - static_v: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+            N is the batch size, E is the embedding dimension. E/num_heads is the head dimension.
+
+            Outputs:
+            - attn_output: :math:`(L, E)` or :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+            E is the embedding dimension.
+            - attn_output_weights: Only returned when ``need_weights=True``. If ``average_attn_weights=True``, returns
+            attention weights averaged across heads of shape :math:`(L, S)` when input is unbatched or
+            :math:`(N, L, S)`, where :math:`N` is the batch size, :math:`L` is the target sequence length, and
+            :math:`S` is the source sequence length. If ``average_attn_weights=False``, returns attention weights per
+            head of shape :math:`(num_heads, L, S)` when input is unbatched or :math:`(N, num_heads, L, S)`.
+        """
+        # NOTE: This code was copied directly from F.multi_head_attention_forward in order to modify it with
+        #       Euclidean attention
+        tens_ops = (query, key, value, in_proj_weight, in_proj_bias, bias_k, bias_v, out_proj_weight, out_proj_bias)
+        if F.has_torch_function(tens_ops):
+            return F.handle_torch_function(
+                F.multi_head_attention_forward,
+                tens_ops,
+                query,
+                key,
+                value,
+                embed_dim_to_check,
+                num_heads,
+                in_proj_weight,
+                in_proj_bias,
+                bias_k,
+                bias_v,
+                add_zero_attn,
+                dropout_p,
+                out_proj_weight,
+                out_proj_bias,
+                training=training,
+                key_padding_mask=key_padding_mask,
+                need_weights=need_weights,
+                attn_mask=attn_mask,
+                use_separate_proj_weight=use_separate_proj_weight,
+                q_proj_weight=q_proj_weight,
+                k_proj_weight=k_proj_weight,
+                v_proj_weight=v_proj_weight,
+                static_k=static_k,
+                static_v=static_v,
+                average_attn_weights=average_attn_weights,
+            )
+
+        is_batched = F._mha_shape_check(query, key, value, key_padding_mask, attn_mask, num_heads)
+
+        # For unbatched input, we unsqueeze at the expected batch-dim to pretend that the input
+        # is batched, run the computation and before returning squeeze the
+        # batch dimension so that the output doesn't carry this temporary batch dimension.
+        if not is_batched:
+            # unsqueeze if the input is unbatched
+            query = query.unsqueeze(1)
+            key = key.unsqueeze(1)
+            value = value.unsqueeze(1)
+            if key_padding_mask is not None:
+                key_padding_mask = key_padding_mask.unsqueeze(0)
+
+        # set up shape vars
+        tgt_len, bsz, embed_dim = query.shape
+        src_len, _, _ = key.shape
+        if key_padding_mask is not None:
+            _kpm_dtype = key_padding_mask.dtype
+            if _kpm_dtype != torch.bool and not torch.is_floating_point(key_padding_mask):
+                raise AssertionError(
+                    "only bool and floating types of key_padding_mask are supported")
+        assert embed_dim == embed_dim_to_check, \
+            f"was expecting embedding dimension of {embed_dim_to_check}, but got {embed_dim}"
+        if isinstance(embed_dim, torch.Tensor):
+            # embed_dim can be a tensor when JIT tracing
+            head_dim = embed_dim.div(num_heads, rounding_mode='trunc')
+        else:
+            head_dim = embed_dim // num_heads
+        assert head_dim * num_heads == embed_dim, f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+        if use_separate_proj_weight:
+            # allow MHA to have different embedding dimensions when separate projection weights are used
+            assert key.shape[:2] == value.shape[:2], \
+                f"key's sequence and batch dims {key.shape[:2]} do not match value's {value.shape[:2]}"
+        else:
+            assert key.shape == value.shape, f"key shape {key.shape} does not match value shape {value.shape}"
+
+        #
+        # compute in-projection
+        #
+        if not use_separate_proj_weight:
+            assert in_proj_weight is not None, "use_separate_proj_weight is False but in_proj_weight is None"
+            q, k, v = F._in_projection_packed(query, key, value, in_proj_weight, in_proj_bias)
+        else:
+            assert q_proj_weight is not None, "use_separate_proj_weight is True but q_proj_weight is None"
+            assert k_proj_weight is not None, "use_separate_proj_weight is True but k_proj_weight is None"
+            assert v_proj_weight is not None, "use_separate_proj_weight is True but v_proj_weight is None"
+            if in_proj_bias is None:
+                b_q = b_k = b_v = None
+            else:
+                b_q, b_k, b_v = in_proj_bias.chunk(3)
+            q, k, v = F._in_projection(query, key, value, q_proj_weight, k_proj_weight, v_proj_weight, b_q, b_k, b_v)
+
+        # prep attention mask
+        if attn_mask is not None:
+            if attn_mask.dtype == torch.uint8:
+                warnings.warn("Byte tensor for attn_mask in nn.MultiheadAttention is deprecated. Use bool tensor instead.")
+                attn_mask = attn_mask.to(torch.bool)
+            else:
+                assert attn_mask.is_floating_point() or attn_mask.dtype == torch.bool, \
+                    f"Only float, byte, and bool types are supported for attn_mask, not {attn_mask.dtype}"
+            # ensure attn_mask's dim is 3
+            if attn_mask.dim() == 2:
+                correct_2d_size = (tgt_len, src_len)
+                if attn_mask.shape != correct_2d_size:
+                    raise RuntimeError(f"The shape of the 2D attn_mask is {attn_mask.shape}, but should be {correct_2d_size}.")
+                attn_mask = attn_mask.unsqueeze(0)
+            elif attn_mask.dim() == 3:
+                correct_3d_size = (bsz * num_heads, tgt_len, src_len)
+                if attn_mask.shape != correct_3d_size:
+                    raise RuntimeError(f"The shape of the 3D attn_mask is {attn_mask.shape}, but should be {correct_3d_size}.")
+            else:
+                raise RuntimeError(f"attn_mask's dimension {attn_mask.dim()} is not supported")
+
+        # add bias along batch dimension (currently second)
+        if bias_k is not None and bias_v is not None:
+            assert static_k is None, "bias cannot be added to static key."
+            assert static_v is None, "bias cannot be added to static value."
+            k = torch.cat([k, bias_k.repeat(1, bsz, 1)])
+            v = torch.cat([v, bias_v.repeat(1, bsz, 1)])
+            if attn_mask is not None:
+                attn_mask = F.pad(attn_mask, (0, 1))
+            if key_padding_mask is not None:
+                key_padding_mask = F.pad(key_padding_mask, (0, 1))
+        else:
+            assert bias_k is None
+            assert bias_v is None
+
+        #
+        # reshape q, k, v for multihead attention and make em batch first
+        #
+        q = q.contiguous().view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
+        if static_k is None:
+            k = k.contiguous().view(k.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        else:
+            # TODO finish disentangling control flow so we don't do in-projections when statics are passed
+            assert static_k.size(0) == bsz * num_heads, \
+                f"expecting static_k.size(0) of {bsz * num_heads}, but got {static_k.size(0)}"
+            assert static_k.size(2) == head_dim, \
+                f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
+            k = static_k
+        if static_v is None:
+            v = v.contiguous().view(v.shape[0], bsz * num_heads, head_dim).transpose(0, 1)
+        else:
+            # TODO finish disentangling control flow so we don't do in-projections when statics are passed
+            assert static_v.size(0) == bsz * num_heads, \
+                f"expecting static_v.size(0) of {bsz * num_heads}, but got {static_v.size(0)}"
+            assert static_v.size(2) == head_dim, \
+                f"expecting static_v.size(2) of {head_dim}, but got {static_v.size(2)}"
+            v = static_v
+
+        # add zero attention along batch dimension (now first)
+        if add_zero_attn:
+            zero_attn_shape = (bsz * num_heads, 1, head_dim)
+            k = torch.cat([k, torch.zeros(zero_attn_shape, dtype=k.dtype, device=k.device)], dim=1)
+            v = torch.cat([v, torch.zeros(zero_attn_shape, dtype=v.dtype, device=v.device)], dim=1)
+            if attn_mask is not None:
+                attn_mask = F.pad(attn_mask, (0, 1))
+            if key_padding_mask is not None:
+                key_padding_mask = F.pad(key_padding_mask, (0, 1))
+
+        # update source sequence length after adjustments
+        src_len = k.size(1)
+
+        # merge key padding and attention masks
+        if key_padding_mask is not None:
+            assert key_padding_mask.shape == (bsz, src_len), \
+                f"expecting key_padding_mask shape of {(bsz, src_len)}, but got {key_padding_mask.shape}"
+            key_padding_mask = key_padding_mask.view(bsz, 1, 1, src_len).   \
+                expand(-1, num_heads, -1, -1).reshape(bsz * num_heads, 1, src_len)
+            if attn_mask is None:
+                attn_mask = key_padding_mask
+            elif attn_mask.dtype == torch.bool:
+                attn_mask = attn_mask.logical_or(key_padding_mask)
+            else:
+                attn_mask = attn_mask.masked_fill(key_padding_mask, float("-inf"))
+
+        # convert mask to float
+        if attn_mask is not None and attn_mask.dtype == torch.bool:
+            new_attn_mask = torch.zeros_like(attn_mask, dtype=q.dtype)
+            new_attn_mask.masked_fill_(attn_mask, float("-inf"))
+            attn_mask = new_attn_mask
+
+        # adjust dropout probability
+        if not training:
+            dropout_p = 0.0
+
+        #
+        # (deep breath) calculate attention and out projection
+        #
+
+        B, Nt, E = q.shape
+        q_scaled = q / math.sqrt(E)
+        if attn_mask is not None:
+            attn_output_weights = torch.baddbmm(attn_mask, q_scaled, k.transpose(-2, -1))
+        else:
+            attn_output_weights = torch.bmm(q_scaled, k.transpose(-2, -1))
+        attn_output_weights = F.softmax(attn_output_weights, dim=-1)
+        if dropout_p > 0.0:
+            attn_output_weights = F.dropout(attn_output_weights, p=dropout_p)
+
+        attn_output = torch.bmm(attn_output_weights, v)
+
+        attn_output = attn_output.transpose(0, 1).contiguous().view(tgt_len * bsz, embed_dim)
+        attn_output = F.linear(attn_output, out_proj_weight, out_proj_bias)
+        attn_output = attn_output.view(tgt_len, bsz, attn_output.size(1))
+
+        if need_weights:
+            # optionally average attention weights over heads
+            attn_output_weights = attn_output_weights.view(bsz, num_heads, tgt_len, src_len)
+            if average_attn_weights:
+                attn_output_weights = attn_output_weights.sum(dim=1) / num_heads
+
+            if not is_batched:
+                # squeeze the output if input was unbatched
+                attn_output = attn_output.squeeze(1)
+                attn_output_weights = attn_output_weights.squeeze(0)
+            return attn_output, attn_output_weights
+        else:
+            if not is_batched:
+                # squeeze the output if input was unbatched
+                attn_output = attn_output.squeeze(1)
+            return attn_output, None

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -201,7 +201,10 @@ class MultiheadAttention(FairseqIncrementalDecoder):
             nn.init.xavier_normal_(self.bias_v)
 
         # Init the temperature param
-        nn.init.constant_(self.temperatures, 1.0) # use temperature=1 (same as normal softmax)
+        if self.learned_temperature:
+            nn.init.uniform_(self.temperatures, 0.8, 1.2) # draw from [0, 1] since temperatures should be positive
+        else:
+            nn.init.constant_(self.temperatures, 1.0) # use temperature=1 (same as normal softmax)
 
     def _get_reserve_head_index(self, num_heads_to_keep: int):
         k_proj_heads_norm = []

--- a/fairseq/modules/multihead_attention.py
+++ b/fairseq/modules/multihead_attention.py
@@ -201,10 +201,7 @@ class MultiheadAttention(FairseqIncrementalDecoder):
             nn.init.xavier_normal_(self.bias_v)
 
         # Init the temperature param
-        if self.learned_temperature:
-            nn.init.uniform_(self.temperatures) # draw from [0, 1] since temperatures should be positive
-        else:
-            nn.init.constant_(self.temperatures, 1.0) # use temperature=1 (same as normal softmax)
+        nn.init.constant_(self.temperatures, 1.0) # use temperature=1 (same as normal softmax)
 
     def _get_reserve_head_index(self, num_heads_to_keep: int):
         k_proj_heads_norm = []

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -136,6 +136,7 @@ class TransformerEncoderLayerBase(nn.Module):
         return MultiheadAttention(
             embed_dim,
             cfg.encoder.attention_heads,
+            cfg.max_source_positions,
             dropout=cfg.attention_dropout,
             self_attention=True,
             q_noise=self.quant_noise,
@@ -356,6 +357,7 @@ class TransformerDecoderLayerBase(nn.Module):
         return MultiheadAttention(
             embed_dim,
             cfg.decoder.attention_heads,
+            cfg.max_source_positions,
             dropout=cfg.attention_dropout,
             add_bias_kv=add_bias_kv,
             add_zero_attn=add_zero_attn,
@@ -372,6 +374,7 @@ class TransformerDecoderLayerBase(nn.Module):
         return MultiheadAttention(
             embed_dim,
             cfg.decoder.attention_heads,
+            cfg.max_source_positions,
             kdim=cfg.encoder.embed_dim,
             vdim=cfg.encoder.embed_dim,
             dropout=cfg.attention_dropout,

--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -141,6 +141,9 @@ class TransformerEncoderLayerBase(nn.Module):
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
             xformers_att_config=cfg.encoder.xformers_att_config,
+            use_euclidean=cfg.use_euclidean_attention,
+            learned_temperature=cfg.learned_temperature,
+            per_token_temperature=cfg.per_token_temperature,
         )
 
     def residual_connection(self, x, residual):
@@ -360,6 +363,9 @@ class TransformerDecoderLayerBase(nn.Module):
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
             xformers_att_config=cfg.decoder.xformers_att_config,
+            use_euclidean=cfg.use_euclidean_attention,
+            learned_temperature=cfg.learned_temperature,
+            per_token_temperature=cfg.per_token_temperature,
         )
 
     def build_encoder_attention(self, embed_dim, cfg):
@@ -373,6 +379,9 @@ class TransformerDecoderLayerBase(nn.Module):
             q_noise=self.quant_noise,
             qn_block_size=self.quant_noise_block_size,
             xformers_att_config=cfg.encoder.xformers_att_config,
+            use_euclidean=cfg.use_euclidean_attention,
+            learned_temperature=cfg.learned_temperature,
+            per_token_temperature=cfg.per_token_temperature,
         )
 
     def prepare_for_onnx_export_(self):

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -181,7 +181,6 @@ class FairseqTask(object):
         Returns:
             np.array: array of filtered sample indices
         """
-        # max_positions = 1024
         indices, ignored = dataset.filter_indices_by_size(indices, max_positions)
         if len(ignored) > 0:
             if not ignore_invalid_inputs:


### PR DESCRIPTION
This PR implements our modified Attention mechanism. This is done through a modification to the `MultiheadAttention` object in the fairseq codebase. Instead of calling `F.multi_head_attention_forward`, this method has been copied into the `MultiheadAttention` class. Then depending on if Euclidean Attention is activated, `self.multi_head_attention_forward` either performs dot-product and `self.softmax`, or substitutes dot-product with pairwise Euclidean distance and uses `self.softmax`. 

NOTE: `self.softmax` has been tested in a separate Colab to be equivalent to `F.softmax` when temperatures are not to be learned (default 1). Otherwise, `self.softmax` allows for a model to learn temperatures and apply them during the softmax step. 